### PR TITLE
Feat/`AccessToken 재발급` 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,12 @@ dependencies {
     runtimeOnly "io.jsonwebtoken:jjwt-gson:${JJWT_VERSION}"
     runtimeOnly "io.jsonwebtoken:jjwt-impl:${JJWT_VERSION}"
 
+    // https://mvnrepository.com/artifact/com.google.guava/guava
+    implementation group: 'com.google.guava', name: 'guava', version: '32.1.3-jre'
+
+    //redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     // lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/aroom/global/config/RedisConfig.java
+++ b/src/main/java/com/aroom/global/config/RedisConfig.java
@@ -1,0 +1,32 @@
+package com.aroom.global.config;
+
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    private final RedisProperties redisProperties;
+
+    public RedisConfig(RedisProperties redisProperties) {
+        this.redisProperties = redisProperties;
+    }
+
+    @Bean
+    RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+    }
+
+    @Bean
+    RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setDefaultSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/aroom/global/jwt/controller/JwtRefreshRestController.java
+++ b/src/main/java/com/aroom/global/jwt/controller/JwtRefreshRestController.java
@@ -1,0 +1,29 @@
+package com.aroom.global.jwt.controller;
+
+import com.aroom.global.jwt.service.JwtService;
+import com.aroom.global.jwt.service.TokenResponse;
+import com.aroom.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import java.time.LocalDateTime;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class JwtRefreshRestController {
+
+	private final JwtService jwtService;
+
+	public JwtRefreshRestController(JwtService jwtService) {
+		this.jwtService = jwtService;
+	}
+
+	@PostMapping("/v1/refresh")
+	public ResponseEntity<ApiResponse<TokenResponse>> refreshAccessToken(@Valid @RequestBody RefreshAccessTokenRequest request) {
+		return ResponseEntity.status(HttpStatus.CREATED)
+			.body(new ApiResponse<>(LocalDateTime.now(), "AccessToken 재발급 성공",
+                jwtService.refreshAccessToken(request)));
+	}
+}

--- a/src/main/java/com/aroom/global/jwt/controller/RefreshAccessTokenRequest.java
+++ b/src/main/java/com/aroom/global/jwt/controller/RefreshAccessTokenRequest.java
@@ -1,0 +1,10 @@
+package com.aroom.global.jwt.controller;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RefreshAccessTokenRequest(
+    @NotBlank String accessToken,
+    @NotBlank String refreshToken
+) {
+
+}

--- a/src/main/java/com/aroom/global/jwt/exception/BadTokenException.java
+++ b/src/main/java/com/aroom/global/jwt/exception/BadTokenException.java
@@ -1,0 +1,10 @@
+package com.aroom.global.jwt.exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class BadTokenException extends AuthenticationException {
+
+    public BadTokenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/aroom/global/jwt/exception/TokenExpiredException.java
+++ b/src/main/java/com/aroom/global/jwt/exception/TokenExpiredException.java
@@ -1,0 +1,10 @@
+package com.aroom.global.jwt.exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class TokenExpiredException extends AuthenticationException {
+
+    public TokenExpiredException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/aroom/global/jwt/model/JwtEntity.java
+++ b/src/main/java/com/aroom/global/jwt/model/JwtEntity.java
@@ -1,0 +1,8 @@
+package com.aroom.global.jwt.model;
+
+public record JwtEntity(
+    String key,
+    String value,
+    long expiration
+) {
+}

--- a/src/main/java/com/aroom/global/jwt/model/TokenType.java
+++ b/src/main/java/com/aroom/global/jwt/model/TokenType.java
@@ -1,0 +1,6 @@
+package com.aroom.global.jwt.model;
+
+public enum TokenType {
+
+    REFRESH
+}

--- a/src/main/java/com/aroom/global/jwt/repository/JwtCacheRepository.java
+++ b/src/main/java/com/aroom/global/jwt/repository/JwtCacheRepository.java
@@ -1,0 +1,31 @@
+package com.aroom.global.jwt.repository;
+
+import com.aroom.global.jwt.model.JwtEntity;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import java.util.concurrent.TimeUnit;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Repository;
+
+@Primary
+@Repository
+public class JwtCacheRepository implements JwtRepository {
+    private final Cache<String, String> tokenStorage;
+
+    public JwtCacheRepository(@Value("${service.jwt.refresh-expiration}") long refreshTokenExpiration) {
+        this.tokenStorage = CacheBuilder.newBuilder()
+            .expireAfterWrite(refreshTokenExpiration, TimeUnit.MILLISECONDS)
+            .build();
+    }
+
+    @Override
+    public void save(JwtEntity entity) {
+        tokenStorage.put(entity.key(), entity.value());
+    }
+
+    @Override
+    public String getValueByKey(String key) {
+        return tokenStorage.getIfPresent(key);
+    }
+}

--- a/src/main/java/com/aroom/global/jwt/repository/JwtRedisRepository.java
+++ b/src/main/java/com/aroom/global/jwt/repository/JwtRedisRepository.java
@@ -1,0 +1,32 @@
+package com.aroom.global.jwt.repository;
+
+import com.aroom.global.jwt.model.JwtEntity;
+import java.util.concurrent.TimeUnit;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 만약 해당 JwtRepository을 사용하고 싶다면 @Primary를 붙이세요
+ * JwtCacheRepository의 @Primary는 제거해야 합니다.
+ * @see com.aroom.global.jwt.repository.JwtCacheRepository
+ */
+@Repository
+public class JwtRedisRepository implements JwtRepository {
+
+    private final ValueOperations<String, String> opsForValue;
+
+    public JwtRedisRepository(RedisTemplate<String, String> redisTemplate) {
+        this.opsForValue = redisTemplate.opsForValue();
+    }
+
+    @Override
+    public void save(JwtEntity entity) {
+        opsForValue.set(entity.key(), entity.value(), entity.expiration(), TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public String getValueByKey(String key) {
+        return opsForValue.get(key);
+    }
+}

--- a/src/main/java/com/aroom/global/jwt/repository/JwtRepository.java
+++ b/src/main/java/com/aroom/global/jwt/repository/JwtRepository.java
@@ -1,0 +1,11 @@
+package com.aroom.global.jwt.repository;
+
+import com.aroom.global.jwt.model.JwtEntity;
+
+public interface JwtRepository {
+
+    void save(JwtEntity entity);
+
+    String getValueByKey(String key);
+
+}

--- a/src/main/java/com/aroom/global/jwt/service/JwtService.java
+++ b/src/main/java/com/aroom/global/jwt/service/JwtService.java
@@ -1,0 +1,83 @@
+package com.aroom.global.jwt.service;
+
+import com.aroom.global.jwt.JwtPayload;
+import com.aroom.global.jwt.JwtUtils;
+import com.aroom.global.jwt.controller.RefreshAccessTokenRequest;
+import com.aroom.global.jwt.exception.BadTokenException;
+import com.aroom.global.jwt.model.JwtEntity;
+import com.aroom.global.jwt.model.TokenType;
+import com.aroom.global.jwt.repository.JwtRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@Service
+public class JwtService {
+
+    private final JwtRepository jwtRepository;
+    private final JwtUtils jwtUtils;
+
+    private final long accessExpiration;
+    private final long refreshExpiration;
+
+    public JwtService(JwtRepository jwtRepository, JwtUtils jwtUtils,
+        @Value("${service.jwt.access-expiration}") long accessExpiration,
+        @Value("${service.jwt.refresh-expiration}") long refreshExpiration) {
+        this.jwtRepository = jwtRepository;
+        this.jwtUtils = jwtUtils;
+        this.accessExpiration = accessExpiration;
+        this.refreshExpiration = refreshExpiration;
+    }
+
+    public TokenResponse createTokenPair(JwtPayload jwtPayload) {
+        String accessToken = jwtUtils.createToken(jwtPayload, accessExpiration);
+        String refreshToken = jwtUtils.createToken(jwtPayload, refreshExpiration);
+
+        jwtRepository.save(
+            new JwtEntity(
+                createSaveKey(TokenType.REFRESH, jwtPayload.email()),
+                createSaveValue(accessToken, refreshToken),
+                refreshExpiration));
+
+        return new TokenResponse(accessToken, refreshToken);
+    }
+
+    public JwtPayload verifyToken(String token) {
+        return jwtUtils.verifyToken(token);
+    }
+
+    public TokenResponse refreshAccessToken(RefreshAccessTokenRequest request) {
+        JwtPayload jwtPayload = verifyToken(request.refreshToken());
+
+        String savedTokenInfo = jwtRepository
+            .getValueByKey(createSaveKey(TokenType.REFRESH, jwtPayload.email()));
+
+        if (!isAcceptable(savedTokenInfo,
+            createSaveValue(request.accessToken(), request.refreshToken()))) {
+            throw new BadTokenException("적절치 않은 RefreshToken 입니다.");
+        }
+
+        String refreshedAccessToken = jwtUtils.createToken(jwtPayload, accessExpiration);
+
+        jwtRepository.save(
+            new JwtEntity(
+                createSaveKey(TokenType.REFRESH, jwtPayload.email()),
+                createSaveValue(refreshedAccessToken, request.refreshToken()),
+                refreshExpiration));
+
+        return new TokenResponse(refreshedAccessToken, request.refreshToken());
+    }
+
+    private boolean isAcceptable(String one, String other) {
+        return one.equals(other);
+    }
+
+    private String createSaveKey(TokenType tokenType, String memberId) {
+        return "%s_%s".formatted(tokenType.name(), memberId);
+    }
+
+    private String createSaveValue(String accessToken, String refreshToken) {
+        return "%s:%s".formatted(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/com/aroom/global/jwt/service/TokenResponse.java
+++ b/src/main/java/com/aroom/global/jwt/service/TokenResponse.java
@@ -1,0 +1,8 @@
+package com.aroom.global.jwt.service;
+
+public record TokenResponse(
+    String accessToken,
+    String refreshToken
+) {
+
+}

--- a/src/test/java/com/aroom/global/jwt/controller/JwtRefreshRestControllerTest.java
+++ b/src/test/java/com/aroom/global/jwt/controller/JwtRefreshRestControllerTest.java
@@ -1,0 +1,55 @@
+package com.aroom.global.jwt.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.aroom.global.jwt.service.JwtService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = JwtRefreshRestController.class)
+class JwtRefreshRestControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private JwtService jwtService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @DisplayName("accessToken이 비어있으면 실패한다.")
+    @Test
+    void accessTokenIsBlank_willFail() throws Exception {
+        mockMvc.perform(post("/v1/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(new RefreshAccessTokenRequest(null, "testToken"))))
+            .andExpect(status().isBadRequest());
+
+        verify(jwtService, never()).refreshAccessToken(any(RefreshAccessTokenRequest.class));
+    }
+
+    @DisplayName("refreshToken이 비어있으면 실패한다.")
+    @Test
+    void refreshTokenIsBlank_willFail() throws Exception {
+        mockMvc.perform(post("/v1/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(new RefreshAccessTokenRequest("testToken", null))))
+            .andExpect(status().isBadRequest());
+
+        verify(jwtService, never()).refreshAccessToken(any(RefreshAccessTokenRequest.class));
+    }
+
+}

--- a/src/test/java/com/aroom/global/jwt/service/JwtServiceTest.java
+++ b/src/test/java/com/aroom/global/jwt/service/JwtServiceTest.java
@@ -1,0 +1,146 @@
+package com.aroom.global.jwt.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.aroom.global.jwt.JwtPayload;
+import com.aroom.global.jwt.controller.RefreshAccessTokenRequest;
+import com.aroom.global.jwt.exception.BadTokenException;
+import com.aroom.global.jwt.exception.TokenExpiredException;
+import com.aroom.global.jwt.repository.JwtRepository;
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class JwtServiceTest {
+
+    @Autowired
+    private JwtService jwtService;
+
+    @Autowired
+    private JwtRepository jwtRepository;
+
+    private final SecretKey secretKey;
+
+    public JwtServiceTest(@Value("${service.jwt.secret-key}") String secretKey) {
+        this.secretKey = Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(secretKey));
+    }
+
+    @DisplayName("토큰 발급은")
+    @Nested
+    class Context_createTokenResponse {
+
+        @DisplayName("토큰을 발급하고, key = REFRESH_email, value = accessToken:refreshToken 으로 저장한다.")
+        @Test
+        void _willSuccess() {
+
+            // given
+            Date date = new Date();
+            JwtPayload jwtPayload = new JwtPayload("test@email.com", date);
+            String savedKey = "REFRESH_" + jwtPayload.email();
+
+            // when
+            TokenResponse tokenResponse = jwtService.createTokenPair(jwtPayload);
+
+            // then
+            JwtParser parser = Jwts.parser().verifyWith(secretKey).build();
+
+            assertDoesNotThrow(() -> parser.parseSignedClaims(tokenResponse.accessToken()));
+            assertDoesNotThrow(() -> parser.parseSignedClaims(tokenResponse.refreshToken()));
+
+            String expectSavedTokenValue = tokenResponse.accessToken() + ":" + tokenResponse.refreshToken();
+            String actualSavedTokenValue = jwtRepository.getValueByKey(savedKey);
+
+            assertEquals(expectSavedTokenValue, actualSavedTokenValue);
+        }
+
+        @DisplayName("email이 null이면 실패한다.")
+        @Test
+        void emailNull_willFail() {
+
+            // given
+            Date date = new Date();
+            JwtPayload jwtPayload = new JwtPayload(null, date);
+
+            // when then
+            assertThrows(NullPointerException.class, () -> jwtService.createTokenPair(jwtPayload));
+        }
+
+
+        @DisplayName("발급 일자(issuedAt)가 null 이면 발급에 실패한다.")
+        @Test
+        void issuedAtNull_willFail() {
+
+            // given
+            JwtPayload jwtPayload = new JwtPayload("test@email.com", null);
+
+            // when then
+            assertThrows(NullPointerException.class, () -> jwtService.createTokenPair(jwtPayload));
+        }
+
+    }
+
+    @DisplayName("accessToken 재발급은")
+    @Nested
+    class Context_refreshAccessToken {
+
+        @DisplayName("accessToken, refreshToken이 정확히 일치해야 재발급 받을 수 있다.")
+        @Test
+        void memberId_accessToken_refreshToken_isEquals_willSuccess() {
+
+            // given
+            Date date = new Date();
+            JwtPayload jwtPayload = new JwtPayload("test@email.com", date);
+            TokenResponse tokenResponse = jwtService.createTokenPair(jwtPayload);
+
+            // when
+            TokenResponse refreshedJwtPair = jwtService.refreshAccessToken(
+                new RefreshAccessTokenRequest(tokenResponse.accessToken(), tokenResponse.refreshToken()));
+
+            // then
+            assertEquals(refreshedJwtPair.refreshToken(), tokenResponse.refreshToken());
+
+            JwtParser parser = Jwts.parser().verifyWith(secretKey).build();
+            assertDoesNotThrow(() -> parser.parseSignedClaims(refreshedJwtPair.accessToken()));
+        }
+
+        @DisplayName("refreshToken이 만료되었다면 실패한다.")
+        @Test
+        void refreshToken_isNotEquals_willThrow_TokenExpiredException() {
+
+            // given
+            JwtPayload jwtPayload = new JwtPayload("test@email.com", new Date(0));
+            TokenResponse tokenResponse = jwtService.createTokenPair(jwtPayload);
+
+            // when then
+            assertThrows(TokenExpiredException.class, () -> jwtService.refreshAccessToken(
+                new RefreshAccessTokenRequest(tokenResponse.accessToken(), tokenResponse.refreshToken())));
+        }
+
+        @DisplayName("가장 최근에 발급된 accessToken이 아니면 실패한다.")
+        @Test
+        void accessToken_notEquals_willThrow_BadTokenException() {
+
+            // given
+            JwtPayload jwtPayload = new JwtPayload("test@email.com", new Date(System.currentTimeMillis()));
+            JwtPayload latestJwtPayload = new JwtPayload("test@email.com", new Date(System.currentTimeMillis() + 10000));
+            TokenResponse tokenResponse = jwtService.createTokenPair(jwtPayload);
+            TokenResponse latestTokenResponse = jwtService.createTokenPair(latestJwtPayload);
+
+            // when then
+            assertThrows(BadTokenException.class, () -> jwtService.refreshAccessToken(
+                new RefreshAccessTokenRequest(tokenResponse.accessToken(), latestTokenResponse.refreshToken())));
+        }
+    }
+}


### PR DESCRIPTION
## 핵심 변경사항
* `AccessToken 재발급` 기능 추가
* Guava.Cache, Redis 도입


## 특이 사항
* 기존 설정으로는 Guava.Cache 설정이 되어있습니다. 만약 Redis가 설치되어있다면 `JwtRedisRepository` 에 `@Primary`를 붙이면 됩니다.


## Issue Link - #25



## Reference
