### PR TITLE
feat: Create controller unitTest helper without SpringSecurity

### DIFF
--- a/src/test/java/com/aroom/domain/accommodation/controller/AccommodationRestControllerTest.java
+++ b/src/test/java/com/aroom/domain/accommodation/controller/AccommodationRestControllerTest.java
@@ -15,35 +15,20 @@ import com.aroom.domain.accommodation.dto.SearchCondition;
 import com.aroom.domain.accommodation.dto.response.AccommodationResponseDTO;
 import com.aroom.domain.accommodation.dto.response.RoomListInfoDTO;
 import com.aroom.domain.accommodation.model.AccommodationImage;
-import com.aroom.domain.accommodation.service.AccommodationService;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.aroom.util.ControllerTestWithoutSecurityHelper;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
-@ExtendWith(MockitoExtension.class)
-@WebMvcTest(AccommodationRestController.class)
-class AccommodationRestControllerTest {
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @MockBean
-    private AccommodationService accommodationService;
+class AccommodationRestControllerTest extends ControllerTestWithoutSecurityHelper {
 
     @Test
     void testFindAllAccommodationWithSearchCondition() throws Exception {
@@ -83,7 +68,7 @@ class AccommodationRestControllerTest {
                 .param("page", "0")
                 .param("size", "10")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(new ObjectMapper().writeValueAsString(mockSearchCondition)))
+                .content(objectMapper.writeValueAsString(mockSearchCondition)))
             .andExpect(MockMvcResultMatchers.status().isOk())
             .andExpect(MockMvcResultMatchers.jsonPath("$.detail").value("숙소 정보를 성공적으로 조회했습니다."))
             .andExpect(MockMvcResultMatchers.jsonPath("$.data").isArray());

--- a/src/test/java/com/aroom/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/aroom/domain/member/controller/MemberControllerTest.java
@@ -4,27 +4,16 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.aroom.domain.member.dto.request.SignUpRequest;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.BeforeAll;
+import com.aroom.util.ControllerTestWithoutSecurityHelper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
-public class MemberControllerTest {
 
-    private static MockMvc mockMvc;
-
-    private final ObjectMapper objectMapper = new ObjectMapper();
-
-    @BeforeAll
-    static void init() {
-        mockMvc = MockMvcBuilders.standaloneSetup(MemberController.class).build();
-    }
+public class MemberControllerTest extends ControllerTestWithoutSecurityHelper {
 
     @DisplayName("회원가입은")
     @Nested
@@ -75,6 +64,4 @@ public class MemberControllerTest {
                 .andExpect(status().isBadRequest());
         }
     }
-
-
 }

--- a/src/test/java/com/aroom/domain/roomCart/controller/RoomCartRestControllerTest.java
+++ b/src/test/java/com/aroom/domain/roomCart/controller/RoomCartRestControllerTest.java
@@ -22,7 +22,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(RoomCartRestController.class)
+@WebMvcTest(controllers = RoomCartRestController.class)
 public class RoomCartRestControllerTest {
 
     @Autowired

--- a/src/test/java/com/aroom/global/jwt/controller/JwtRefreshRestControllerTest.java
+++ b/src/test/java/com/aroom/global/jwt/controller/JwtRefreshRestControllerTest.java
@@ -6,27 +6,12 @@ import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.aroom.global.jwt.service.JwtService;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.aroom.util.ControllerTestWithoutSecurityHelper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(controllers = JwtRefreshRestController.class)
-class JwtRefreshRestControllerTest {
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @MockBean
-    private JwtService jwtService;
-
-    @Autowired
-    private ObjectMapper objectMapper;
+class JwtRefreshRestControllerTest extends ControllerTestWithoutSecurityHelper {
 
     @DisplayName("accessToken이 비어있으면 실패한다.")
     @Test

--- a/src/test/java/com/aroom/util/ControllerTestWithoutSecurityHelper.java
+++ b/src/test/java/com/aroom/util/ControllerTestWithoutSecurityHelper.java
@@ -1,0 +1,45 @@
+package com.aroom.util;
+
+import com.aroom.domain.accommodation.controller.AccommodationRestController;
+import com.aroom.domain.accommodation.service.AccommodationService;
+import com.aroom.domain.member.controller.MemberController;
+import com.aroom.domain.member.service.MemberService;
+import com.aroom.domain.reservation.service.ReservationService;
+import com.aroom.global.jwt.controller.JwtRefreshRestController;
+import com.aroom.global.jwt.service.JwtService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.catalina.security.SecurityConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+    controllers = {MemberController.class, JwtRefreshRestController.class,
+        AccommodationRestController.class},
+    excludeFilters = {
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)},
+    excludeAutoConfiguration = SecurityAutoConfiguration.class)
+public class ControllerTestWithoutSecurityHelper {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @MockBean
+    protected MemberService memberService;
+
+    @MockBean
+    protected JwtService jwtService;
+
+    @MockBean
+    protected ReservationService reservationService;
+
+    @MockBean
+    protected AccommodationService accommodationService;
+}


### PR DESCRIPTION
## 핵심 변경사항
- `ControllerTestWithoutSecurityHelper` 생성
- 유닛 테스트에 적용


## 특이 사항
* 시큐리티를 제외하고 유닛테스트를 적용하고 싶다면 `ControllerTestWithoutSecurityHelper`에 해당 controller를 등록한 후  를 상속받으시면 됩니다.
* 내부적으로 필요한 빈 역시 등록해주세요!
```java
@WebMvcTest(
    controllers = {MemberRestController.class}, // 여기에 Controller Class 등록
    excludeFilters = {
        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)},
    excludeAutoConfiguration = SecurityAutoConfiguration.class)
public class ControllerTestWithoutSecurityHelper {

    @Autowired
    protected MockMvc mockMvc;

    @Autowired
    protected ObjectMapper objectMapper;

    @MockBean
    protected MemberService memberService; // 이렇게 빈 의존성 추가
}
``
## Issue Link - #48
