### PR TITLE
hotfix: LoginFilter, AccountContext 수정

### DIFF
--- a/src/main/java/com/aroom/global/security/account/CustomUserDetailsService.java
+++ b/src/main/java/com/aroom/global/security/account/CustomUserDetailsService.java
@@ -3,13 +3,16 @@ package com.aroom.global.security.account;
 import com.aroom.domain.member.exception.MemberNotFoundException;
 import com.aroom.domain.member.model.Member;
 import com.aroom.domain.member.repository.MemberRepository;
+import java.util.List;
 import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 public class CustomUserDetailsService implements UserDetailsService {
 
@@ -21,6 +24,9 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        log.info("username: {}", username);
+        List<Member> all = memberRepository.findAll();
+        log.info("memberList: {}", all);
         Member member = memberRepository.findMemberByEmail(username)
             .orElseThrow(MemberNotFoundException::new);
 

--- a/src/main/java/com/aroom/global/security/formlogin/CustomFormLoginProvider.java
+++ b/src/main/java/com/aroom/global/security/formlogin/CustomFormLoginProvider.java
@@ -21,13 +21,12 @@ public class CustomFormLoginProvider implements AuthenticationProvider {
     @Override
     public Authentication authenticate(Authentication authentication)
         throws AuthenticationException {
-        String username = (String) authentication.getPrincipal();
-        String password = (String) authentication.getCredentials();
+        AccountContext requestContext = (AccountContext) authentication.getPrincipal();
 
         AccountContext accountContext = (AccountContext) userDetailsService
-            .loadUserByUsername(username);
+            .loadUserByUsername(requestContext.getUsername());
 
-        if (!passwordEncoder.matches(password, accountContext.getPassword())) {
+        if (!passwordEncoder.matches(requestContext.getPassword(), accountContext.getPassword())) {
             throw new BadCredentialsException("Login Fail");
         }
 

--- a/src/main/java/com/aroom/global/security/formlogin/CustomLoginToken.java
+++ b/src/main/java/com/aroom/global/security/formlogin/CustomLoginToken.java
@@ -27,7 +27,7 @@ public class CustomLoginToken extends AbstractAuthenticationToken {
 
     @Override
     public Object getPrincipal() {
-        return accountContext.getUsername();
+        return accountContext;
     }
 
     @Override


### PR DESCRIPTION
## 핵심 변경사항
- `CustomLoginToken.java` 수정

- `CustomLoginToken.getPrinciple()` 에서 `AccountContext를` 반환하지 않고 String 을 반환해 `CastingException`이 발생하였습니다. 이를 수정했습니다.
