### PR TITLE
fix: CORS Setting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     testImplementation 'org.springframework.security:spring-security-test:6.2.0'
     runtimeOnly 'com.mysql:mysql-connector-j'
-    testImplementation 'org.springframework.security:spring-security-test:6.2.0'
 
     // JWT
     implementation "io.jsonwebtoken:jjwt-api:${JJWT_VERSION}"

--- a/src/main/java/com/aroom/global/security/SecurityConfig.java
+++ b/src/main/java/com/aroom/global/security/SecurityConfig.java
@@ -5,7 +5,6 @@ import com.aroom.global.security.formlogin.CustomFormLoginFilter;
 import com.aroom.global.security.formlogin.CustomFormLoginProvider;
 import com.aroom.global.security.jwt.JwtAuthenticationFilter;
 import com.aroom.global.security.jwt.JwtAuthenticationProvider;
-import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -15,9 +14,6 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
@@ -61,15 +57,5 @@ public class SecurityConfig {
 	@Bean
 	JwtAuthenticationFilter jwtAuthenticationFilter() throws Exception {
 		return new JwtAuthenticationFilter(authenticationManager());
-	}
-
-	@Bean
-	CorsConfigurationSource corsConfigurationSource() {
-		CorsConfiguration configuration = new CorsConfiguration();
-		configuration.setAllowedOrigins(List.of("http://localhost:3000"));
-		configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
-		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-		source.registerCorsConfiguration("/**", configuration);
-		return source;
 	}
 }

--- a/src/main/java/com/aroom/global/security/SecurityFilterConfig.java
+++ b/src/main/java/com/aroom/global/security/SecurityFilterConfig.java
@@ -2,6 +2,7 @@ package com.aroom.global.security;
 
 import com.aroom.global.security.formlogin.CustomFormLoginFilter;
 import com.aroom.global.security.jwt.JwtAuthenticationFilter;
+import java.util.Arrays;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,6 +12,7 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
 
 @Configuration
 public class SecurityFilterConfig {
@@ -30,6 +32,15 @@ public class SecurityFilterConfig {
 		http
 			.httpBasic(AbstractHttpConfigurer::disable)
 			.formLogin(AbstractHttpConfigurer::disable)
+			.cors(cors -> cors.configurationSource(request -> {
+                CorsConfiguration configuration = new CorsConfiguration();
+                configuration.setAllowCredentials(true);
+                configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000", "http://localhost:3001"));
+                configuration.setAllowedHeaders(Arrays.asList("*"));
+                configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+                configuration.addExposedHeader("X-AUTH-TOKEN");
+				return configuration;
+            }))
 			.csrf(AbstractHttpConfigurer::disable)
 			.sessionManagement(sessionConfig ->
 				sessionConfig.sessionCreationPolicy(SessionCreationPolicy.STATELESS));


### PR DESCRIPTION
## 핵심 변경사항
- `CorsFilter`를 직접 등록을 해줘야 CORS Allow가 수행됩니다. 해당 필터를 등록합니다.
- `corsConfigurationSource`을 bean 제거
- `cors` 필터 등록