### PR TITLE
refactor : Querydsl 로직 버그 수정 및 페이지네이션 버그 수정

### DIFF
--- a/src/main/java/com/aroom/domain/accommodation/controller/AccommodationRestController.java
+++ b/src/main/java/com/aroom/domain/accommodation/controller/AccommodationRestController.java
@@ -38,7 +38,7 @@ public class AccommodationRestController {
         @Nullable @RequestParam(defaultValue = "10") int size
     ) {
 
-        if (validateSearchConditionIsNull(searchCondition)) {
+        if (validateQueryParamIsNull(searchCondition, page, size)) {
 
             Sort sortCondition = Sort.by(
                 Direction.fromOptionalString(searchCondition.getOrderBy())
@@ -59,7 +59,7 @@ public class AccommodationRestController {
 
     }
 
-    private boolean validateSearchConditionIsNull(SearchCondition searchCondition) {
+    private boolean validateQueryParamIsNull(SearchCondition searchCondition, int page, int size) {
         if (searchCondition.getOrderCondition()!=null ||
         searchCondition.getHighestPrice()!=null||
         searchCondition.getLowestPrice()!=null||
@@ -69,7 +69,9 @@ public class AccommodationRestController {
         searchCondition.getName()!=null||
         searchCondition.getOrderBy()!=null||
         searchCondition.getAddressCode()!=null||
-        searchCondition.getPhoneNumber()!=null){
+        searchCondition.getPhoneNumber()!=null||
+        page!=0||
+        size!=0){
             return true;
         }
         return false;

--- a/src/main/java/com/aroom/domain/accommodation/controller/AccommodationRestController.java
+++ b/src/main/java/com/aroom/domain/accommodation/controller/AccommodationRestController.java
@@ -34,8 +34,8 @@ public class AccommodationRestController {
     @GetMapping("")
     public ResponseEntity<ApiResponse<List<AccommodationListResponse>>> findAllAccommodation(
         @Nullable @ModelAttribute @Valid SearchCondition searchCondition,
-        @Nullable @RequestParam(defaultValue = "0") int page,
-        @Nullable @RequestParam(defaultValue = "10") int size
+        @Nullable @RequestParam(defaultValue = "0") Integer page,
+        @Nullable @RequestParam(defaultValue = "10") Integer size
     ) {
 
         if (validateQueryParamIsNull(searchCondition, page, size)) {
@@ -59,7 +59,7 @@ public class AccommodationRestController {
 
     }
 
-    private boolean validateQueryParamIsNull(SearchCondition searchCondition, int page, int size) {
+    private boolean validateQueryParamIsNull(SearchCondition searchCondition, Integer page, Integer size) {
         if (searchCondition.getOrderCondition()!=null ||
         searchCondition.getHighestPrice()!=null||
         searchCondition.getLowestPrice()!=null||
@@ -70,8 +70,8 @@ public class AccommodationRestController {
         searchCondition.getOrderBy()!=null||
         searchCondition.getAddressCode()!=null||
         searchCondition.getPhoneNumber()!=null||
-        page!=0||
-        size!=0){
+        page!= null||
+        size!= null){
             return true;
         }
         return false;

--- a/src/main/java/com/aroom/domain/accommodation/repository/AccommodationRepositoryImpl.java
+++ b/src/main/java/com/aroom/domain/accommodation/repository/AccommodationRepositoryImpl.java
@@ -66,13 +66,29 @@ public class AccommodationRepositoryImpl implements AccommodationRepositoryCusto
         if (searchCondition.getPhoneNumber() != null) {
             booleanBuilder.and(accommodation.phoneNumber.eq(searchCondition.getPhoneNumber()));
         }
-        if (searchCondition.getLowestPrice() != null) {
-            booleanBuilder.and(accommodation.roomList.any().price.goe(
-                Integer.parseInt(searchCondition.getLowestPrice())));
-        }
-        if (searchCondition.getHighestPrice() != null) {
-            booleanBuilder.and(accommodation.roomList.any().price.goe(
-                Integer.parseInt(searchCondition.getHighestPrice())));
+
+        //lowestPrice와 higestPrice가 둘 다 NULL이 아닌 경우
+        if (searchCondition.getLowestPrice() != null &&
+            searchCondition.getHighestPrice() != null) {
+            booleanBuilder.and(accommodation.roomList.any().price.between(
+                Integer.parseInt(searchCondition.getLowestPrice())
+                , Integer.parseInt(searchCondition.getHighestPrice()))
+            );
+        }else {
+            // lowestPrice는 존재하고, highestPrice만 NULL인 경우
+            if (searchCondition.getLowestPrice() != null &&
+                searchCondition.getHighestPrice() == null) {
+                System.out.println("1");
+                booleanBuilder.and(accommodation.roomList.any().price.goe(
+                    Integer.parseInt(searchCondition.getLowestPrice())));
+            }
+            // lowestPrice는 NULL이고 , highestPrice만 존재하는 경우
+            if (searchCondition.getLowestPrice()==null&&
+                searchCondition.getHighestPrice() != null) {
+                System.out.println("2");
+                booleanBuilder.and(accommodation.roomList.any().price.loe(
+                    Integer.parseInt(searchCondition.getHighestPrice())));
+            }
         }
         if (searchCondition.getCheckIn() != null) {
             booleanBuilder.and(


### PR DESCRIPTION
## 핵심 변경사항
Querydsl:
if 문을 수정하여 lowestPrice와 higestPrice가 모두 null인 경우, 둘 중 하나만 null인 경우로 분기하여 로직을 수정했습니다.

Pagination:
validate 메서드에 page, size가 포함되어 있지 않아서, 쿼리 스트링으로 page와 size를 넘겨도 전체조회 메서드를 타도록 되어있던 버그를 수정했습니다.
Null 체크를 위해 page, size의 자료형을 int 에서 Integer로 변경했습니다.

## Issue Link - #1
22

