### PR TITLE
fix: Member Index 제거

### DIFF
--- a/src/main/java/com/aroom/domain/member/model/Member.java
+++ b/src/main/java/com/aroom/domain/member/model/Member.java
@@ -1,8 +1,8 @@
 package com.aroom.domain.member.model;
 
 
-import com.aroom.global.basetime.BaseTimeEntity;
 import com.aroom.domain.cart.model.Cart;
+import com.aroom.global.basetime.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -10,17 +10,12 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToOne;
-import jakarta.persistence.Index;
-import jakarta.persistence.Table;
 import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Table(indexes = {
-    @Index(name = "idx_email", columnList = "email", unique = true)
-})
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -44,7 +39,8 @@ public class Member extends BaseTimeEntity {
     private Cart cart;
 
     @Builder
-    private Member(String email, String password, String name) {
+    private Member(Long id, String email, String password, String name) {
+        this.id = id;
         this.email = email;
         this.password = password;
         this.name = name;

--- a/src/test/java/com/aroom/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/aroom/domain/member/service/MemberServiceTest.java
@@ -1,5 +1,6 @@
 package com.aroom.domain.member.service;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
@@ -7,6 +8,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.aroom.domain.member.exception.MemberEmailDuplicateException;
+import com.aroom.domain.member.model.Member;
 import com.aroom.domain.member.repository.MemberRepository;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -41,7 +43,7 @@ class MemberServiceTest {
             given(memberRepository.findMemberByEmail(anyString())).willReturn(Optional.empty());
 
             // when then
-            assertThatThrownBy(() -> memberService.validateEmailDuplicatation(targetEmail))
+            assertThatCode(() -> memberService.validateEmailDuplicatation(targetEmail))
                 .doesNotThrowAnyException();
             verify(memberRepository, times(1)).findMemberByEmail(anyString());
         }
@@ -52,7 +54,8 @@ class MemberServiceTest {
 
             // given
             String targetEmail = "test@email.com";
-            given(memberRepository.findMemberByEmail(anyString())).willReturn(Optional.empty());
+            given(memberRepository.findMemberByEmail(anyString()))
+                .willReturn(Optional.of(Member.builder().build()));
 
             // when then
             assertThatThrownBy(() -> memberService.validateEmailDuplicatation(targetEmail))


### PR DESCRIPTION
## 핵심 변경사항
- Member Entity에서 email로 조회하는 케이스가 많아서 email 따로 index 등록을 했습니다. 해당 기능이 추가되면서 email 로 검색하는 기능이 실패하는 케이스가 발생하기 시작했습니다. (`findByEmail()` 실패함.) 우선적으로 문제 해결을 위해 이를 제거하고 추후 이유를 찾아볼 예정입니다.
- `Member` Entity의 `idx_email` 제거

# Issue Link - #64
