### PR TITLE
refactor: email 제거, name 추가

### DIFF
--- a/src/main/java/com/aroom/domain/reservation/controller/ReservationRestController.java
+++ b/src/main/java/com/aroom/domain/reservation/controller/ReservationRestController.java
@@ -30,6 +30,6 @@ public class ReservationRestController {
 
         return ResponseEntity.status(HttpStatus.CREATED).body(new ApiResponse<>(LocalDateTime.now(),
             "객실 예약에 성공했습니다.",
-            reservationService.reserveRoom(request, loginInfo.email())));
+            reservationService.reserveRoom(request, loginInfo.memberId())));
     }
 }

--- a/src/main/java/com/aroom/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/aroom/domain/reservation/service/ReservationService.java
@@ -37,9 +37,9 @@ public class ReservationService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public ReservationResponse reserveRoom(ReservationRequest request, String username) {
-        Member member = memberRepository.findMemberByEmail(username).orElseThrow(
-            MemberNotFoundException::new);;
+    public ReservationResponse reserveRoom(ReservationRequest request, Long id) {
+        Member member = memberRepository.findById(id).orElseThrow(
+            MemberNotFoundException::new);
         Reservation reservation = Reservation.builder()
             .member(member)
             .agreement(request.getAgreement())

--- a/src/main/java/com/aroom/global/jwt/JwtUtils.java
+++ b/src/main/java/com/aroom/global/jwt/JwtUtils.java
@@ -19,8 +19,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class JwtUtils {
 
-    private static final String USER_KEY = "user-key";
-    private static final String USER_EMAIL = "user-email";
+    private static final String USER_ID_KEY = "user-key";
+    private static final String USER_NAME_KEY = "user-name";
 
     @Value("${spring.application.name}")
     private String issuer;
@@ -34,8 +34,8 @@ public class JwtUtils {
     public String createToken(JwtPayload jwtPayload, Date issuedAt, long expiration) {
         return Jwts.builder()
             // Gson 에서 Long 을 Double 로 Parse 하는 Issue가 있어서 String으로 Wrapping함.
-            .claim(USER_KEY, Objects.requireNonNull(jwtPayload.id().toString()))
-            .claim(USER_EMAIL, Objects.requireNonNull(jwtPayload.email()))
+            .claim(USER_ID_KEY, Objects.requireNonNull(jwtPayload.id().toString()))
+            .claim(USER_NAME_KEY, Objects.requireNonNull(jwtPayload.name()))
             .issuer(issuer)
             .issuedAt(issuedAt)
             .expiration(new Date(issuedAt.getTime() + expiration))
@@ -48,8 +48,8 @@ public class JwtUtils {
             Jws<Claims> claimsJws = Jwts.parser().verifyWith(secretKey).build()
                 .parseSignedClaims(jwtToken);
             Claims payload = claimsJws.getPayload();
-            return new JwtPayload(Long.parseLong(payload.get(USER_KEY, String.class)), // Gson 에서 Long 을 Double 로 Parse 하는 Issue가 있어서 String으로 Wrapping함.8
-                payload.get(USER_EMAIL, String.class));
+            return new JwtPayload(Long.parseLong(payload.get(USER_ID_KEY, String.class)), // Gson 에서 Long 을 Double 로 Parse 하는 Issue가 있어서 String으로 Wrapping함.8
+                payload.get(USER_NAME_KEY, String.class));
         } catch (ExpiredJwtException e) {
             throw new TokenExpiredException(e.getMessage());
         } catch (JwtException e) {

--- a/src/main/java/com/aroom/global/jwt/dto/JwtCreateRequest.java
+++ b/src/main/java/com/aroom/global/jwt/dto/JwtCreateRequest.java
@@ -4,7 +4,7 @@ import java.util.Date;
 
 public record JwtCreateRequest(
     Long memberId,
-    String email,
+    String name,
     Date issuedAt
 ) {
 }

--- a/src/main/java/com/aroom/global/jwt/model/JwtPayload.java
+++ b/src/main/java/com/aroom/global/jwt/model/JwtPayload.java
@@ -2,7 +2,7 @@ package com.aroom.global.jwt.model;
 
 public record JwtPayload(
     Long id,
-    String email
+    String name
 ) {
 
 }

--- a/src/main/java/com/aroom/global/jwt/service/JwtService.java
+++ b/src/main/java/com/aroom/global/jwt/service/JwtService.java
@@ -33,7 +33,7 @@ public class JwtService {
     }
 
     public TokenResponse createTokenPair(JwtCreateRequest request) {
-        JwtPayload jwtPayload = new JwtPayload(request.memberId(), request.email());
+        JwtPayload jwtPayload = new JwtPayload(request.memberId(), request.name());
         String accessToken = jwtUtils.createToken(jwtPayload, request.issuedAt(), accessExpiration);
         String refreshToken = jwtUtils.createToken(jwtPayload, request.issuedAt(), refreshExpiration);
 

--- a/src/main/java/com/aroom/global/resolver/LoginInfo.java
+++ b/src/main/java/com/aroom/global/resolver/LoginInfo.java
@@ -2,7 +2,7 @@ package com.aroom.global.resolver;
 
 public record LoginInfo(
     Long memberId,
-    String email
+    String name
 ) {
 
 }

--- a/src/main/java/com/aroom/global/resolver/LoginInfoArgumentResolver.java
+++ b/src/main/java/com/aroom/global/resolver/LoginInfoArgumentResolver.java
@@ -19,7 +19,7 @@ public class LoginInfoArgumentResolver implements HandlerMethodArgumentResolver 
 
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         AccountContext accountContext = (AccountContext) authentication.getPrincipal();
-        return new LoginInfo(accountContext.getMemberId(), accountContext.getUsername());
+        return new LoginInfo(accountContext.getMemberId(), accountContext.getName());
     }
 
     @Override

--- a/src/main/java/com/aroom/global/security/account/AccountContext.java
+++ b/src/main/java/com/aroom/global/security/account/AccountContext.java
@@ -1,6 +1,7 @@
 package com.aroom.global.security.account;
 
 import java.util.Collection;
+import java.util.Collections;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -9,16 +10,35 @@ import org.springframework.security.core.userdetails.UserDetails;
 public class AccountContext implements UserDetails {
 
     private final Long memberId;
+    private final String name;
     private final String username;
     private final String password;
     private final Collection<GrantedAuthority> authorities;
 
-    public AccountContext(Long memberId, String username, String password,
+    private AccountContext(Long memberId, String name, String username, String password,
         Collection<GrantedAuthority> authorities) {
         this.memberId = memberId;
+        this.name = name;
         this.username = username;
         this.password = password;
         this.authorities = authorities;
+    }
+
+    public static AccountContext beforeLoginContext(String username, String password) {
+        return new AccountContext(null, null, username, password, Collections.emptySet());
+    }
+
+    public static AccountContext withToken(String token) {
+        return new AccountContext(null, null, null, token, Collections.emptySet());
+    }
+
+    public static AccountContext loginedContext(Long memberId, String name, Collection<GrantedAuthority> authorities) {
+        return new AccountContext(memberId, name, null, null, authorities);
+    }
+
+    public static AccountContext fullContext(Long memberId, String name, String username, String password,
+        Collection<GrantedAuthority> authorities) {
+        return new AccountContext(memberId, name, username, password, authorities);
     }
 
     @Override

--- a/src/main/java/com/aroom/global/security/account/CustomUserDetailsService.java
+++ b/src/main/java/com/aroom/global/security/account/CustomUserDetailsService.java
@@ -21,10 +21,11 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+
         Member member = memberRepository.findMemberByEmail(username)
             .orElseThrow(MemberNotFoundException::new);
 
-        return new AccountContext(member.getId(), member.getEmail(), member.getPassword(),
-            Set.of(new SimpleGrantedAuthority("ROLE_USER")));
+        return AccountContext.fullContext(member.getId(), member.getName(), member.getEmail(),
+            member.getPassword(), Set.of(new SimpleGrantedAuthority("ROLE_USER")));
     }
 }

--- a/src/main/java/com/aroom/global/security/formlogin/CustomLoginToken.java
+++ b/src/main/java/com/aroom/global/security/formlogin/CustomLoginToken.java
@@ -1,28 +1,24 @@
 package com.aroom.global.security.formlogin;
 
 import com.aroom.global.security.account.AccountContext;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.Objects;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
-import org.springframework.security.core.GrantedAuthority;
 
 public class CustomLoginToken extends AbstractAuthenticationToken {
 
     private final AccountContext accountContext;
 
-    private CustomLoginToken(AccountContext accountContext,
-        Collection<? extends GrantedAuthority> authorities) {
-        super(authorities);
+    private CustomLoginToken(AccountContext accountContext) {
+        super(accountContext.getAuthorities());
         this.accountContext = accountContext;
     }
 
     public static CustomLoginToken unAuthenticate(String username, String password) {
-        return new CustomLoginToken(new AccountContext(null, username, password, Collections.emptySet()), Collections.emptySet());
+        return new CustomLoginToken(AccountContext.beforeLoginContext(username, password));
     }
 
     public static CustomLoginToken authenticate(AccountContext accountContext) {
-        return new CustomLoginToken(accountContext, accountContext.getAuthorities());
+        return new CustomLoginToken(accountContext);
     }
 
     @Override

--- a/src/main/java/com/aroom/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/aroom/global/security/jwt/JwtAuthenticationFilter.java
@@ -7,7 +7,6 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.Collections;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -32,7 +31,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         SecurityContextHolder.getContext()
             .setAuthentication(authenticationManager.authenticate(
-                JwtAuthenticationToken.unAuthorize(new AccountContext(null, null, accessToken, Collections.emptySet()))));
+                JwtAuthenticationToken.unAuthorize(AccountContext.withToken(accessToken))));
 
         chain.doFilter(request, response);
     }

--- a/src/main/java/com/aroom/global/security/jwt/JwtAuthenticationProvider.java
+++ b/src/main/java/com/aroom/global/security/jwt/JwtAuthenticationProvider.java
@@ -26,7 +26,7 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
         JwtPayload jwtPayload = jwtService.verifyToken(accessToken);
 
         return JwtAuthenticationToken.authorize(
-            new AccountContext(jwtPayload.id(), jwtPayload.email(), null,
+            AccountContext.loginedContext(jwtPayload.id(), jwtPayload.name(),
                 Set.of(new SimpleGrantedAuthority("ROLE_USER"))));
     }
 

--- a/src/test/java/com/aroom/domain/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/aroom/domain/reservation/service/ReservationServiceTest.java
@@ -85,6 +85,7 @@ class ReservationServiceTest {
             .build();
 
         tester = Member.builder()
+            .id(1L)
             .name("김패캠")
             .email("qwgwf@naver.com")
             .password("56124WDA2@")
@@ -127,14 +128,14 @@ class ReservationServiceTest {
                 .personnel(request.getPersonnel())
                 .build();
 
-            given(memberRepository.findMemberByEmail(any())).willReturn(Optional.of(tester));
+            given(memberRepository.findById(any())).willReturn(Optional.of(tester));
             given(roomRepository.findByIdWithLock(any())).willReturn(Optional.of(testRoom));
             given(reservationRoomRepository.save(any())).willReturn(reservationRoom);
             given(reservationRepository.save(any())).willReturn(reservation);
             given(roomImageRepository.findById(any())).willReturn(Optional.of(roomImage));
 
             // when
-            ReservationResponse response = reservationService.reserveRoom(request, tester.getEmail());
+            ReservationResponse response = reservationService.reserveRoom(request, tester.getId());
 
             // then
             Assertions.assertThat(response).isNotNull();
@@ -159,13 +160,13 @@ class ReservationServiceTest {
                 .isFromCart(false)
                 .build();
 
-            given(memberRepository.findMemberByEmail(any())).willReturn(Optional.of(tester));
+            given(memberRepository.findById(any())).willReturn(Optional.of(tester));
             given(roomRepository.findByIdWithLock(any())).willReturn(Optional.of(testRoom));
             given(reservationRoomRepository.getOverlappingReservationByDateRange(any(), any(), any())).willReturn(2);
 
             // when then
             Assertions.assertThatThrownBy(() -> {
-                    reservationService.reserveRoom(request, tester.getName());
+                    reservationService.reserveRoom(request, tester.getId());
                 }).isInstanceOf(RuntimeException.class)
                 .hasMessage("방이 품절 되었습니다.");
         }

--- a/src/test/java/com/aroom/global/jwt/JwtUtilsTest.java
+++ b/src/test/java/com/aroom/global/jwt/JwtUtilsTest.java
@@ -32,6 +32,8 @@ class JwtUtilsTest {
     @Value("${service.jwt.access-expiration}")
     private Long accessExpiration;
 
+    private static final String USER_ID_KEY = "user-key";
+    private static final String USER_NAME_KEY = "user-name";
     private final SecretKey secretKey;
     private final SecretKey badSecretKey;
 
@@ -106,8 +108,8 @@ class JwtUtilsTest {
             JwtPayload targetPayload = new JwtPayload(1L, "test@email.com");
 
             String accessToken = Jwts.builder()
-                .claim("user-key", targetPayload.id().toString())
-                .claim("user-email", targetPayload.email())
+                .claim(USER_ID_KEY, targetPayload.id().toString())
+                .claim(USER_NAME_KEY, targetPayload.name())
                 .issuer(applicationName)
                 .issuedAt(issueDate)
                 .expiration(new Date(issueDate.getTime() + accessExpiration))
@@ -118,7 +120,7 @@ class JwtUtilsTest {
             JwtPayload jwtPayload = jwtUtils.verifyToken(accessToken);
 
             // then
-            assertThat(jwtPayload.email()).isEqualTo(targetPayload.email());
+            assertThat(jwtPayload.name()).isEqualTo(targetPayload.name());
         }
 
         @DisplayName("SecretKey가 일치하지 않으면 BadTokenException가 발생한다.")
@@ -127,11 +129,11 @@ class JwtUtilsTest {
 
             // given
             Date issueDate = new Date(System.currentTimeMillis());
-            JwtPayload targetPayload = new JwtPayload(1L, "test@email.com");
+            JwtPayload targetPayload = new JwtPayload(1L, "test@name.com");
 
             String accessToken = Jwts.builder()
-                .claim("user-key", targetPayload.id().toString())
-                .claim("user-email", targetPayload.email())
+                .claim(USER_ID_KEY, targetPayload.id().toString())
+                .claim(USER_NAME_KEY, targetPayload.name())
                 .issuer(applicationName)
                 .issuedAt(issueDate)
                 .expiration(new Date(issueDate.getTime() + accessExpiration))
@@ -149,11 +151,11 @@ class JwtUtilsTest {
 
             // given
             Date issueDate = new Date(System.currentTimeMillis());
-            JwtPayload targetPayload = new JwtPayload(1L, "test@email.com");
+            JwtPayload targetPayload = new JwtPayload(1L, "test@name.com");
 
             String accessToken = Jwts.builder()
-                .claim("user-key", targetPayload.id().toString())
-                .claim("user-email", targetPayload.email())
+                .claim(USER_ID_KEY, targetPayload.id().toString())
+                .claim(USER_NAME_KEY, targetPayload.name())
                 .issuer(applicationName)
                 .issuedAt(issueDate)
                 .expiration(new Date(issueDate.getTime() - 10000))


### PR DESCRIPTION
## 핵심 변경사항
- JWT의 payload 에서 email을 제거하고 name을 추가합니다. 이유는 다음과 같습니다.
1. local storage 에 회원의 name을 저장할 필요성이 생김 (header에 노출)
2. email의 같은 경우 개인정보이기 때문에 제거(필요하다면 넣겠지만 현재는 최소화하는 것이 좋다고 판단함.)

- jwt payload email 제거 및 name 추가
- filter, resolver 에서 name으로 변경함.

## 특이 사항



## Issue Link - #67



## Reference
