### PR TITLE
fix: 객실 이미지 Response 클래스 삭제에 따른 수정

### DIFF
--- a/src/test/java/com/aroom/domain/reservation/controller/ReservationRestControllerTest.java
+++ b/src/test/java/com/aroom/domain/reservation/controller/ReservationRestControllerTest.java
@@ -13,7 +13,6 @@ import com.aroom.domain.reservation.dto.request.ReservationRequest;
 import com.aroom.domain.reservation.dto.response.ReservationResponse;
 import com.aroom.domain.reservation.service.ReservationService;
 import com.aroom.domain.room.dto.request.RoomReservationRequest;
-import com.aroom.domain.room.dto.response.RoomImageResponse;
 import com.aroom.domain.room.dto.response.RoomReservationResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDate;
@@ -53,8 +52,6 @@ class ReservationRestControllerTest {
             .endDate(LocalDate.of(2023, 12, 23))
             .build();
 
-        RoomImageResponse roomImageResponse = new RoomImageResponse("ww.com");
-
         RoomReservationResponse roomResponse = RoomReservationResponse.builder()
             .roomId(1L)
             .type("패밀리")
@@ -65,12 +62,12 @@ class ReservationRestControllerTest {
             .price(100000)
             .startDate(roomRequest.getStartDate())
             .endDate(roomRequest.getEndDate())
-            .roomImage(roomImageResponse)
+            .roomImageUrl("testimage.com")
+            .roomReservationNumber(1L)
             .build();
 
         reservationResponse = ReservationResponse.builder()
             .roomList(List.of(roomResponse))
-            .roomReservationNumber(2L)
             .reservationNumber(3L)
             .dealDateTime(LocalDateTime.now())
             .build();


### PR DESCRIPTION
## 핵심 변경사항
RoomImageResponse가 삭제되어 사용하는 곳에서 생긴 에러를 해결했습니다.

## Issue Link - #75