### PR TITLE
Feat/#73 Address 엔티티 추가 및 지역분류 필터링 기능 추가

### DIFF
--- a/src/main/java/com/aroom/domain/accommodation/controller/AccommodationRestController.java
+++ b/src/main/java/com/aroom/domain/accommodation/controller/AccommodationRestController.java
@@ -2,15 +2,11 @@ package com.aroom.domain.accommodation.controller;
 
 import com.aroom.domain.accommodation.dto.AccommodationListResponse;
 import com.aroom.domain.accommodation.dto.SearchCondition;
-import com.aroom.domain.accommodation.dto.response.AccommodationResponse;
 import com.aroom.domain.accommodation.service.AccommodationService;
-import com.aroom.global.resolver.Login;
-import com.aroom.global.resolver.LoginInfo;
 import com.aroom.global.response.ApiResponse;
 import jakarta.annotation.Nullable;
 import jakarta.validation.Valid;
 import java.time.LocalDateTime;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -51,11 +47,11 @@ public class AccommodationRestController {
 
             PageRequest pageRequest = PageRequest.of(page, size);
 
-            if (searchCondition.getStartDate() !=null && searchCondition.getEndDate() != null){
+            if (searchCondition.getStartDate() != null && searchCondition.getEndDate() != null) {
                 return ResponseEntity.status(HttpStatus.OK)
                     .body(new ApiResponse<>(LocalDateTime.now(), "숙소 정보를 성공적으로 조회했습니다",
                         accommodationService.getAccommodationListByDateSearchCondition(
-                            searchCondition,pageRequest,sortCondition
+                            searchCondition, pageRequest, sortCondition
                         )));
             }
 
@@ -72,20 +68,23 @@ public class AccommodationRestController {
     }
 
 
-
-    private boolean validateQueryParamIsNull(SearchCondition searchCondition, Integer page, Integer size) {
-        if (searchCondition.getOrderCondition()!=null ||
-        searchCondition.getHighestPrice()!=null||
-        searchCondition.getLowestPrice()!=null||
-        searchCondition.getCheckIn()!=null||
-        searchCondition.getCheckOut()!=null||
-        searchCondition.getLikeCount()!=null||
-        searchCondition.getName()!=null||
-        searchCondition.getOrderBy()!=null||
-        searchCondition.getAddressCode()!=null||
-        searchCondition.getPhoneNumber()!=null||
-        page!= null||
-        size!= null){
+    private boolean validateQueryParamIsNull(SearchCondition searchCondition, Integer page,
+        Integer size) {
+        if (searchCondition.getOrderCondition() != null ||
+            searchCondition.getHighestPrice() != null ||
+            searchCondition.getLowestPrice() != null ||
+            searchCondition.getCheckIn() != null ||
+            searchCondition.getCheckOut() != null ||
+            searchCondition.getLikeCount() != null ||
+            searchCondition.getName() != null ||
+            searchCondition.getOrderBy() != null ||
+            searchCondition.getPhoneNumber() != null ||
+            searchCondition.getAreaCode() != null ||
+            searchCondition.getAreaName() != null ||
+            searchCondition.getSigunguCode() != null ||
+            searchCondition.getSigunguName() != null ||
+            page != null ||
+            size != null) {
             return true;
         }
         return false;

--- a/src/main/java/com/aroom/domain/accommodation/dto/AccommodationListResponse.java
+++ b/src/main/java/com/aroom/domain/accommodation/dto/AccommodationListResponse.java
@@ -76,7 +76,6 @@ public class AccommodationListResponse {
                 .latitude(accommodation.getLatitude())
                 .longitude(accommodation.getLongitude())
                 .likeCount(accommodation.getLikeCount())
-                .addressCode(accommodation.getAddressCode())
                 .phoneNumber(accommodation.getPhoneNumber())
                 .price(minimumPrice)
                 .accommodationImageUrl(imageUrl)

--- a/src/main/java/com/aroom/domain/accommodation/dto/SearchCondition.java
+++ b/src/main/java/com/aroom/domain/accommodation/dto/SearchCondition.java
@@ -19,7 +19,8 @@ import org.springframework.format.annotation.DateTimeFormat;
 public class SearchCondition {
 
     private String name;
-    private String addressCode;
+    private String areaName;
+    private String sigunguName;
     private String likeCount;
     private String phoneNumber;
     private String lowestPrice;
@@ -32,6 +33,9 @@ public class SearchCondition {
 
     private LocalDate startDate;
     private LocalDate endDate;
+
+    private Integer areaCode;
+    private Integer sigunguCode;
 
     private String orderBy;
     private String orderCondition;

--- a/src/main/java/com/aroom/domain/accommodation/dto/SearchCondition.java
+++ b/src/main/java/com/aroom/domain/accommodation/dto/SearchCondition.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.DateTimeFormat.ISO;
 
 @Getter
 @Setter
@@ -26,12 +27,14 @@ public class SearchCondition {
     private String lowestPrice;
     private String highestPrice;
     private Integer capacity;
-    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @DateTimeFormat(pattern = "HH:mm")
     private LocalTime checkIn;
-    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @DateTimeFormat(pattern = "HH:mm")
     private LocalTime checkOut;
 
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
     private LocalDate startDate;
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
     private LocalDate endDate;
 
     private Integer areaCode;

--- a/src/main/java/com/aroom/domain/accommodation/model/Accommodation.java
+++ b/src/main/java/com/aroom/domain/accommodation/model/Accommodation.java
@@ -1,5 +1,6 @@
 package com.aroom.domain.accommodation.model;
 
+import com.aroom.domain.address.model.Address;
 import com.aroom.domain.room.model.Room;
 import com.aroom.global.basetime.BaseTimeEntity;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
@@ -9,7 +10,9 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -37,9 +40,6 @@ public class Accommodation extends BaseTimeEntity {
     private float longitude;
 
     @Column(nullable = false)
-    private String addressCode;
-
-    @Column(nullable = false)
     private String address;
 
     @Column(nullable = false)
@@ -47,7 +47,6 @@ public class Accommodation extends BaseTimeEntity {
 
     @Column(nullable = false)
     private String phoneNumber;
-
 
     @JsonManagedReference
     @OneToMany(mappedBy = "accommodation", fetch = FetchType.LAZY)
@@ -57,19 +56,23 @@ public class Accommodation extends BaseTimeEntity {
     @OneToMany(mappedBy = "accommodation", fetch = FetchType.LAZY)
     private List<AccommodationImage> accommodationImageList = new ArrayList<>();
 
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "address_id", nullable = false)
+    private Address addressEntity;
+
     @Builder
-    public Accommodation(String name, float latitude, float longitude, String addressCode,
+    public Accommodation(Long id, String name, float latitude, float longitude,
         String address, int likeCount, String phoneNumber, List<Room> roomList,
-        List<AccommodationImage> accommodationImageList) {
+        List<AccommodationImage> accommodationImageList, Address addressEntity) {
+        this.id = id;
         this.name = name;
         this.latitude = latitude;
         this.longitude = longitude;
-        this.addressCode = addressCode;
         this.address = address;
         this.likeCount = likeCount;
         this.phoneNumber = phoneNumber;
         this.roomList = roomList;
         this.accommodationImageList = accommodationImageList;
+        this.addressEntity = addressEntity;
     }
-
 }

--- a/src/main/java/com/aroom/domain/accommodation/repository/AccommodationRepositoryImpl.java
+++ b/src/main/java/com/aroom/domain/accommodation/repository/AccommodationRepositoryImpl.java
@@ -93,12 +93,20 @@ public class AccommodationRepositoryImpl implements AccommodationRepositoryCusto
 
     private BooleanBuilder booleanBuilderProvider(SearchCondition searchCondition) {
         BooleanBuilder booleanBuilder = new BooleanBuilder();
+        if (searchCondition.getAreaCode()!=null){
+            booleanBuilder.and(accommodation.addressEntity.areaCode.eq(searchCondition.getAreaCode()));
+        }
+        if (searchCondition.getAreaName()!=null){
+            booleanBuilder.and(accommodation.addressEntity.areaName.contains(searchCondition.getAreaName()));
+        }
+        if (searchCondition.getSigunguCode()!=null){
+            booleanBuilder.and(accommodation.addressEntity.sigunguCode.eq(searchCondition.getSigunguCode()));
+        }
+        if (searchCondition.getSigunguName()!=null){
+            booleanBuilder.and(accommodation.addressEntity.sigunguName.contains(searchCondition.getSigunguName()));
+        }
         if (searchCondition.getName() != null) {
             booleanBuilder.and(accommodation.name.contains(searchCondition.getName()));
-        }
-        if (searchCondition.getAddressCode() != null) {
-            booleanBuilder.and(
-                accommodation.addressCode.eq(searchCondition.getAddressCode()));
         }
         if (searchCondition.getLikeCount() != null) {
             booleanBuilder.and(
@@ -112,7 +120,6 @@ public class AccommodationRepositoryImpl implements AccommodationRepositoryCusto
                 //숙소의 최대수용인원이 사용자가 입력한 인원수보다 무조건 커야함
                 accommodation.roomList.any().maxCapacity.goe(searchCondition.getCapacity()));
         }
-
         //lowestPrice와 higestPrice가 둘 다 NULL이 아닌 경우
         if (searchCondition.getLowestPrice() != null &&
             searchCondition.getHighestPrice() != null) {

--- a/src/main/java/com/aroom/domain/address/model/Address.java
+++ b/src/main/java/com/aroom/domain/address/model/Address.java
@@ -1,0 +1,48 @@
+package com.aroom.domain.address.model;
+
+import com.aroom.domain.accommodation.model.Accommodation;
+import com.aroom.global.basetime.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Address extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "address_id", updatable = false)
+    private Long id;
+
+    @Column(nullable = false)
+    private Integer areaCode;
+
+    @Column(nullable = false)
+    private Integer sigunguCode;
+
+    @Column(nullable = false)
+    private String areaName;
+
+    @Column(nullable = false)
+    private String sigunguName;
+
+    @Builder
+    public Address(Long id, Integer areaCode, Integer sigunguCode, String areaName,
+        String sigunguName) {
+        this.id = id;
+        this.areaCode = areaCode;
+        this.sigunguCode = sigunguCode;
+        this.areaName = areaName;
+        this.sigunguName = sigunguName;
+    }
+}

--- a/src/main/java/com/aroom/domain/address/repository/AddressRepository.java
+++ b/src/main/java/com/aroom/domain/address/repository/AddressRepository.java
@@ -1,0 +1,8 @@
+package com.aroom.domain.address.repository;
+
+import com.aroom.domain.address.model.Address;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AddressRepository extends JpaRepository<Address, Long> {
+
+}


### PR DESCRIPTION
## 핵심 변경사항

- Address 엔티티를 추가했습니다. 
- Accommodation과 OneToOne 연관관계이고, Accommodation이 Address의 외래키를 필드로 가지고 있습니다.
- areaCode, sigunguCode, areaName,  sigunguName 을 쿼리스트링으로 넘겨서 해당하는 숙소를 필터링 하는 기능을 추가했습니다.

## Issue Link - #73 