### PR TITLE
refactor: Custom Header의 `_`를 `-`으로 변경

### DIFF
--- a/src/main/java/com/aroom/global/config/CustomHttpHeaders.java
+++ b/src/main/java/com/aroom/global/config/CustomHttpHeaders.java
@@ -4,6 +4,6 @@ import org.springframework.http.HttpHeaders;
 
 public class CustomHttpHeaders extends HttpHeaders {
 
-    public static final String ACCESS_TOKEN = "Access_Token";
-    public static final String REFRESH_TOKEN = "Refresh_Token";
+    public static final String ACCESS_TOKEN = "Access-Token";
+    public static final String REFRESH_TOKEN = "Refresh-Token";
 }


### PR DESCRIPTION
## 핵심 변경사항
- RFC 규약에 맞게 Custom Header의 `_`를 `-`으로 변경합니다.
- `Access_Token` to `Access-Token`
- `Refresh_Token` to `Refresh-Token`

## Issue Link - #90 

