### PR TITLE
refactor: Login ResponseHeader 에 Content-Type 추가

### DIFF
--- a/src/main/java/com/aroom/global/security/formlogin/CustomFormLoginFilter.java
+++ b/src/main/java/com/aroom/global/security/formlogin/CustomFormLoginFilter.java
@@ -10,6 +10,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Date;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
@@ -49,6 +51,7 @@ public class CustomFormLoginFilter extends AbstractAuthenticationProcessingFilte
         throws IOException {
         AccountContext context = (AccountContext) authResult.getPrincipal();
         TokenResponse tokenResponse = jwtService.createTokenPair(new JwtCreateRequest(context.getMemberId(), context.getName(), new Date()));
+        response.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
         response.getWriter().write(objectMapper.writeValueAsString(tokenResponse));
     }
 }


### PR DESCRIPTION
## 핵심 변경사항
- login api의 responseHeader에 `Content-Type: application/json` 입력

## Issue Link - #88