### PR TITLE
fix: RestDocs 전용 ObjectMapper에 StdDateFormat 추가

### DIFF
--- a/src/test/java/com/aroom/util/docs/RestDocsHelper.java
+++ b/src/test/java/com/aroom/util/docs/RestDocsHelper.java
@@ -20,7 +20,7 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 public abstract class RestDocsHelper {
 
     protected MockMvc mockMvc;
-    protected ObjectMapper objectMapper = new ObjectMapper();
+    protected ObjectMapper objectMapper = new ObjectMapper().setDateFormat(new StdDateFormat());
 
     @BeforeEach
     void setUp(RestDocumentationContextProvider provider) {


### PR DESCRIPTION
## 핵심 변경사항
- `ObjectMapper`의 dateFormat를 `StdDateFormat` 으로 설정


## 특이 사항
- 핫픽스라 강제로 Merge 하겠습니다.
