### PR TITLE
feat: 재고, 판매량 업데이트, 동시성 제어 처리

### DIFF
--- a/src/main/java/com/aroom/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/aroom/domain/reservation/service/ReservationService.java
@@ -67,7 +67,7 @@ public class ReservationService {
 
             Long reservationRoomId = 0L;
             for (RoomProduct roomProduct : roomProductList) {
-                roomProduct.sellProduct();
+                roomProduct.sellRoomProduct();
 
                 ReservationRoom reservationRoom = ReservationRoom.builder()
                     .roomProduct(roomProduct)

--- a/src/main/java/com/aroom/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/aroom/domain/reservation/service/ReservationService.java
@@ -53,10 +53,12 @@ public class ReservationService {
         List<RoomReservationResponse> responseRoomList = new ArrayList<>();
 
         for (RoomReservationRequest roomRequest : request.getRoomList()) {
-            Room requiredRoom = roomRepository.findByIdWithLock(roomRequest.getRoomId())
+            Room requiredRoom = roomRepository.findById(roomRequest.getRoomId())
                 .orElseThrow(RuntimeException::new);
 
             checkCapacityOfRoom(request.getPersonnel(), requiredRoom);
+
+            requiredRoom.addSoldCount();
 
             List<RoomProduct> roomProductList = roomProductRepository.findByRoomAndBetweenStartDateAndEndDate(
                 requiredRoom, roomRequest.getStartDate(), roomRequest.getEndDate());
@@ -65,6 +67,8 @@ public class ReservationService {
 
             Long reservationRoomId = 0L;
             for (RoomProduct roomProduct : roomProductList) {
+                roomProduct.sellProduct();
+
                 ReservationRoom reservationRoom = ReservationRoom.builder()
                     .roomProduct(roomProduct)
                     .reservation(reservation)

--- a/src/main/java/com/aroom/domain/room/model/Room.java
+++ b/src/main/java/com/aroom/domain/room/model/Room.java
@@ -85,4 +85,8 @@ public class Room extends BaseTimeEntity {
         this.soldCount = soldCount;
         this.roomImageList = roomImageList;
     }
+
+    public void addSoldCount(){
+        soldCount++;
+    }
 }

--- a/src/main/java/com/aroom/domain/roomProduct/model/RoomProduct.java
+++ b/src/main/java/com/aroom/domain/roomProduct/model/RoomProduct.java
@@ -39,9 +39,6 @@ public class RoomProduct extends BaseTimeEntity {
     @Column(nullable = false)
     private LocalDate startDate;
 
-    @Version
-    private Long version;
-
     @Builder
     public RoomProduct(Long id, Room room, Integer stock, LocalDate startDate) {
         this.id = id;

--- a/src/main/java/com/aroom/domain/roomProduct/model/RoomProduct.java
+++ b/src/main/java/com/aroom/domain/roomProduct/model/RoomProduct.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Version;
 import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -38,11 +39,18 @@ public class RoomProduct extends BaseTimeEntity {
     @Column(nullable = false)
     private LocalDate startDate;
 
+    @Version
+    private Long version;
+
     @Builder
     public RoomProduct(Long id, Room room, Integer stock, LocalDate startDate) {
         this.id = id;
         this.room = room;
         this.stock = stock;
         this.startDate = startDate;
+    }
+
+    public void sellRoomProduct(){
+        this.stock--;
     }
 }

--- a/src/main/java/com/aroom/domain/roomProduct/repository/RoomProductRepository.java
+++ b/src/main/java/com/aroom/domain/roomProduct/repository/RoomProductRepository.java
@@ -3,10 +3,12 @@ package com.aroom.domain.roomProduct.repository;
 import com.aroom.domain.room.model.Room;
 import com.aroom.domain.roomProduct.model.RoomProduct;
 import io.lettuce.core.dynamic.annotation.Param;
+import jakarta.persistence.LockModeType;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Repository;
@@ -16,6 +18,7 @@ public interface RoomProductRepository extends JpaRepository<RoomProduct, Long> 
 
     Optional<RoomProduct> findByRoomId(Long roomId);
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select rp from RoomProduct rp where rp.room = :room and (rp.startDate between :startDate and :endDate)")
     List<RoomProduct> findByRoomAndBetweenStartDateAndEndDate(@Param("room")Room room, @Param("startDate")
         LocalDate startDate, @Param("endDate") LocalDate endDate);


### PR DESCRIPTION
## 핵심 변경사항
예약 후 방의 판매량, 상품의 재고 수량을 변경하는 로직을 추가했습니다.
동시성 이슈를 해결하기 위해 RoomProduct에 비관적 락(읽기, 쓰기 제어)을 추가하였습니다.
RoomProduct를 예약 하기 위해 조회 할 때 Lock을 걸어 접근을 막도록 하였습니다.

## Issue Link - #75
