### PR TITLE
fix: 장바구니가 없는 회원이 조회시 생기는 오류 수정

### DIFF
--- a/src/main/java/com/aroom/domain/roomCart/service/RoomCartService.java
+++ b/src/main/java/com/aroom/domain/roomCart/service/RoomCartService.java
@@ -77,7 +77,7 @@ public class RoomCartService {
         return new RoomCartResponse(cart);
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public FindCartResponse getCartList(Long memberId) {
         Optional<Cart> cartOptional = cartRepository.findByMemberId(memberId);
         Cart cart = null;

--- a/src/main/java/com/aroom/domain/roomCart/service/RoomCartService.java
+++ b/src/main/java/com/aroom/domain/roomCart/service/RoomCartService.java
@@ -77,7 +77,7 @@ public class RoomCartService {
         return new RoomCartResponse(cart);
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public FindCartResponse getCartList(Long memberId) {
         Optional<Cart> cartOptional = cartRepository.findByMemberId(memberId);
         Cart cart = null;
@@ -87,6 +87,8 @@ public class RoomCartService {
                     memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new))
                 .roomCartList(new ArrayList<>())
                 .build();
+
+            cart = cartRepository.save(cart);
         }else{
             cart = cartOptional.get();
         }

--- a/src/main/java/com/aroom/domain/roomCart/service/RoomCartService.java
+++ b/src/main/java/com/aroom/domain/roomCart/service/RoomCartService.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.checkerframework.checker.units.qual.A;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -78,8 +79,17 @@ public class RoomCartService {
 
     @Transactional
     public FindCartResponse getCartList(Long memberId) {
-        Cart cart = cartRepository.findByMemberId(memberId)
-            .orElseThrow(CartNotFoundException::new);
+        Optional<Cart> cartOptional = cartRepository.findByMemberId(memberId);
+        Cart cart = null;
+        if(cartOptional.isEmpty()){
+            cart = Cart.builder()
+                .member(
+                    memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new))
+                .roomCartList(new ArrayList<>())
+                .build();
+        }else{
+            cart = cartOptional.get();
+        }
 
         List<RoomCart> roomCartList = cart.getRoomCartList();
         return createResponse(roomCartList);


### PR DESCRIPTION
## 핵심 변경사항
장바구니가 없는 회원이 장바구니 조회를 요청했을 때 빈 리스트로 반환하도록 변경했습니다.


## Issue Link - #121
