### PR TITLE
hotFix: 장바구니 객실 추가시, endDate 포함 x

### DIFF
--- a/src/main/java/com/aroom/domain/roomCart/controller/RoomCartRestControllerAdvice.java
+++ b/src/main/java/com/aroom/domain/roomCart/controller/RoomCartRestControllerAdvice.java
@@ -3,6 +3,7 @@ package com.aroom.domain.roomCart.controller;
 import com.aroom.domain.roomCart.exception.OutOfStockException;
 import com.aroom.domain.roomCart.exception.RoomCartNotFoundException;
 import com.aroom.domain.roomCart.exception.WrongDateException;
+import com.aroom.domain.roomProduct.exception.RoomProductNotFoundException;
 import com.aroom.global.response.ApiResponse;
 import java.time.LocalDateTime;
 import org.springframework.http.HttpStatus;
@@ -23,6 +24,13 @@ public class RoomCartRestControllerAdvice {
     @ExceptionHandler(RoomCartNotFoundException.class)
     public ResponseEntity<ApiResponse<Void>> RoomCartNotFoundException(
         RoomCartNotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body(new ApiResponse<>(LocalDateTime.now(), e.getMessage(), null));
+    }
+
+    @ExceptionHandler(RoomProductNotFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> RoomProductNotFoundException(
+        RoomProductNotFoundException e) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
             .body(new ApiResponse<>(LocalDateTime.now(), e.getMessage(), null));
     }

--- a/src/main/java/com/aroom/domain/roomCart/service/RoomCartService.java
+++ b/src/main/java/com/aroom/domain/roomCart/service/RoomCartService.java
@@ -57,7 +57,7 @@ public class RoomCartService {
 
         List<RoomProduct> roomProductList = roomProductRepository.findByRoomIdAndStartDateAndEndDate(
             room_id,
-            roomCartRequest.getStartDate(), roomCartRequest.getEndDate());
+            roomCartRequest.getStartDate(), roomCartRequest.getEndDate().minusDays(1));
 
         checkContinualDate(roomProductList, roomCartRequest);
 

--- a/src/main/java/com/aroom/domain/roomCart/service/RoomCartService.java
+++ b/src/main/java/com/aroom/domain/roomCart/service/RoomCartService.java
@@ -55,9 +55,15 @@ public class RoomCartService {
             return cartRepository.save(new Cart(member));
         });
 
-        List<RoomProduct> roomProductList = roomProductRepository.findByRoomIdAndStartDateAndEndDate(
-            room_id,
-            roomCartRequest.getStartDate(), roomCartRequest.getEndDate().minusDays(1));
+        List<RoomProduct> roomProductList;
+        if(roomCartRequest.getStartDate().equals(roomCartRequest.getEndDate().minusDays(1))){
+            roomProductList = roomProductRepository.findByRoomIdAndStartDate(
+                room_id, roomCartRequest.getStartDate());
+        } else {
+            roomProductList = roomProductRepository.findByRoomIdAndStartDateAndEndDate(
+                room_id,
+                roomCartRequest.getStartDate(), roomCartRequest.getEndDate().minusDays(1));
+        }
 
         checkContinualDate(roomProductList, roomCartRequest);
 

--- a/src/main/java/com/aroom/domain/roomProduct/repository/RoomProductRepository.java
+++ b/src/main/java/com/aroom/domain/roomProduct/repository/RoomProductRepository.java
@@ -15,6 +15,10 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface RoomProductRepository extends JpaRepository<RoomProduct, Long> {
 
+    @Query("select rp from RoomProduct rp where rp.room.id = :roomId and rp.startDate =:startDate and rp.stock > 0")
+    List<RoomProduct> findByRoomIdAndStartDate(@Param("roomId") long roomId,
+        @Param("startDate") LocalDate startDate);
+
     @Query("select rp from RoomProduct rp where rp.room.id = :roomId and (rp.startDate between :startDate and :endDate) and rp.stock > 0")
     List<RoomProduct> findByRoomIdAndStartDateAndEndDate(@Param("roomId") long roomId,
         @Param("startDate")

--- a/src/test/java/com/aroom/domain/roomCart/service/RoomCartServiceTest.java
+++ b/src/test/java/com/aroom/domain/roomCart/service/RoomCartServiceTest.java
@@ -91,7 +91,7 @@ public class RoomCartServiceTest {
                 Optional.ofNullable(roomProduct));
             List<RoomProduct> roomProductList = List.of(roomProduct);
             given(roomProductRepository.findByRoomIdAndStartDateAndEndDate(any(Long.TYPE),
-                eq(roomCartRequest.getStartDate()), eq(roomCartRequest.getEndDate()))).willReturn(
+                eq(roomCartRequest.getStartDate()), eq(roomCartRequest.getEndDate().minusDays(1)))).willReturn(
                 roomProductList);
 
             RoomCart roomCart = RoomCart.builder().id(1L).roomProduct(roomProduct).cart(cart)
@@ -137,7 +137,7 @@ public class RoomCartServiceTest {
                 Optional.ofNullable(roomProduct));
             List<RoomProduct> roomProductList = List.of(roomProduct);
             given(roomProductRepository.findByRoomIdAndStartDateAndEndDate(any(Long.TYPE),
-                eq(roomCartRequest.getStartDate()), eq(roomCartRequest.getEndDate()))).willReturn(
+                eq(roomCartRequest.getStartDate()), eq(roomCartRequest.getEndDate().minusDays(1)))).willReturn(
                 roomProductList);
 
             RoomCart roomCart = RoomCart.builder().id(1L).roomProduct(roomProduct).cart(cart)

--- a/src/test/java/com/aroom/domain/roomCart/service/RoomCartServiceTest.java
+++ b/src/test/java/com/aroom/domain/roomCart/service/RoomCartServiceTest.java
@@ -65,7 +65,7 @@ public class RoomCartServiceTest {
     class Context_postRoomCart {
 
         @Test
-        @DisplayName("장바구니에 객실을 등록할 수 있다.")
+        @DisplayName("1박투숙도 장바구니에 객실을 등록할 수 있다.")
         void CartSave_willSuccess() {
             // given
             long memberId = 1L;
@@ -90,9 +90,8 @@ public class RoomCartServiceTest {
             given(roomProductRepository.findByStock(anyInt())).willReturn(
                 Optional.ofNullable(roomProduct));
             List<RoomProduct> roomProductList = List.of(roomProduct);
-            given(roomProductRepository.findByRoomIdAndStartDateAndEndDate(any(Long.TYPE),
-                eq(roomCartRequest.getStartDate()), eq(roomCartRequest.getEndDate().minusDays(1)))).willReturn(
-                roomProductList);
+            given(roomProductRepository.findByRoomIdAndStartDate(any(Long.TYPE),eq(roomCartRequest.getStartDate()))).willReturn(roomProductList);
+
 
             RoomCart roomCart = RoomCart.builder().id(1L).roomProduct(roomProduct).cart(cart)
                 .build();
@@ -100,6 +99,65 @@ public class RoomCartServiceTest {
             cart.postRoomCarts(roomCart);
             given(roomCartRepository.findByRoomProductId(roomProductId)).willReturn(roomCartList);
             given(roomCartRepository.save(any(RoomCart.class))).willReturn(roomCart);
+
+            // when
+            RoomCartResponse roomCartResponse = roomCartService.postRoomCart(memberId, roomId,
+                roomCartRequest);
+
+            // then
+            assertThat(roomCartResponse.getRoomCartList().get(0).getRoom_id()).isEqualTo(roomId);
+        }
+
+        @Test
+        @DisplayName("장기투숙도 장바구니에 객실을 등록할 수 있다.")
+        void CartLongSave_willSuccess() {
+            // given
+            long memberId = 1L;
+            long roomId = 1L;
+            RoomCartRequest roomCartRequest = RoomCartRequest.builder()
+                .startDate(LocalDate.of(2023, 11, 27)).endDate(LocalDate.of(2023, 11, 30)).build();
+
+            Member member = Member.builder().id(1L).email("yang980329@naver.com").name("양유림")
+                .password("123!!!").build();
+            Cart cart = Cart.builder().id(1L).member(member).roomCartList(new ArrayList<>())
+                .build();
+            given(cartRepository.findByMemberId(any(Long.TYPE))).willReturn(Optional.of(cart));
+
+            Room room = Room.builder().id(1L).type("DELUXE").price(350000).capacity(2)
+                .maxCapacity(4)
+                .checkIn(
+                    LocalTime.of(15, 0)).checkOut(LocalTime.of(11, 0))
+                .build();
+            RoomProduct roomProduct1 = RoomProduct.builder().id(1L).room(room)
+                .startDate(roomCartRequest.getStartDate()).stock(4).build();
+            RoomProduct roomProduct2 = RoomProduct.builder().id(2L).room(room)
+                .startDate(roomCartRequest.getStartDate()).stock(2).build();
+            RoomProduct roomProduct3 = RoomProduct.builder().id(3L).room(room)
+                .startDate(roomCartRequest.getStartDate()).stock(3).build();
+            given(roomProductRepository.findByStock(anyInt())).willReturn(
+                Optional.ofNullable(roomProduct2));
+            List<RoomProduct> roomProductList = List.of(roomProduct1,roomProduct2,roomProduct3);
+            given(roomProductRepository.findByRoomIdAndStartDateAndEndDate(any(Long.TYPE),
+                eq(roomCartRequest.getStartDate()), eq(roomCartRequest.getEndDate().minusDays(1)))).willReturn(
+                roomProductList);
+
+            RoomCart roomCart1 = RoomCart.builder().id(1L).roomProduct(roomProduct1).cart(cart)
+                .build();
+            RoomCart roomCart2 = RoomCart.builder().id(2L).roomProduct(roomProduct2).cart(cart)
+                .build();
+            RoomCart roomCart3 = RoomCart.builder().id(3L).roomProduct(roomProduct3).cart(cart)
+                .build();
+            roomCartRepository.save(roomCart1);
+            roomCartRepository.save(roomCart2);
+            roomCartRepository.save(roomCart3);
+
+            List<RoomCart> roomCartList = List.of(roomCart1,roomCart2,roomCart3);
+            List<RoomCart> roomCartMinList = List.of(roomCart2);
+            cart.postRoomCarts(roomCart1);
+            cart.postRoomCarts(roomCart2);
+            cart.postRoomCarts(roomCart3);
+            given(roomCartRepository.findByRoomProductId(roomProduct2.getId())).willReturn(roomCartMinList);
+            given(roomCartRepository.save(any(RoomCart.class))).willReturn(roomCart1);
 
             // when
             RoomCartResponse roomCartResponse = roomCartService.postRoomCart(memberId, roomId,
@@ -136,8 +194,8 @@ public class RoomCartServiceTest {
             given(roomProductRepository.findByStock(anyInt())).willReturn(
                 Optional.ofNullable(roomProduct));
             List<RoomProduct> roomProductList = List.of(roomProduct);
-            given(roomProductRepository.findByRoomIdAndStartDateAndEndDate(any(Long.TYPE),
-                eq(roomCartRequest.getStartDate()), eq(roomCartRequest.getEndDate().minusDays(1)))).willReturn(
+            given(roomProductRepository.findByRoomIdAndStartDate(any(Long.TYPE),
+                eq(roomCartRequest.getStartDate()))).willReturn(
                 roomProductList);
 
             RoomCart roomCart = RoomCart.builder().id(1L).roomProduct(roomProduct).cart(cart)


### PR DESCRIPTION
## 핵심 변경사항
- 단기투숙과 장기투숙 로직을 구별하고 수정했습니다.
- 단기투숙시, startDate의 roomProduct만 넘기고
- 장기투숙시, startDate ~ endDate-1만 넘겨야 하므로 수정했습니다.
- RoomProductNotFound Exception Handler를 추가했습니다.

