### PR TITLE
Hotfix : 정렬조건 GroupBy절 삭제

### DIFF
--- a/src/main/java/com/aroom/domain/accommodation/repository/AccommodationRepositoryImpl.java
+++ b/src/main/java/com/aroom/domain/accommodation/repository/AccommodationRepositoryImpl.java
@@ -107,7 +107,6 @@ public class AccommodationRepositoryImpl implements AccommodationRepositoryCusto
             .join(accommodation.roomList, room)
             .where(booleanBuilderProvider(searchCondition)
                 , greaterOrEqualsCapacity(searchCondition))
-            .groupBy(accommodation.roomList.any().price)
             .offset(((long) pageable.getPageNumber() * pageable.getPageSize()))
             .limit(pageable.getPageSize())
             .orderBy(getOrderBy(sortCondition))


### PR DESCRIPTION
정렬조건에서 GroupBy절 때문에 price가 같은 방들은 한 그룹으로 묶여서, 하나만 나오는 문제가 발생했습니다.
GroupBy절을 삭제해서 문제 해결했습니다.



